### PR TITLE
Fix: wrong scope with the mask

### DIFF
--- a/MLX90393.cpp
+++ b/MLX90393.cpp
@@ -537,8 +537,8 @@ setResolution(uint8_t res_x, uint8_t res_y, uint8_t res_z)
   uint16_t old_val;
   uint8_t status1 = readRegister(RES_XYZ_REG, old_val);
   uint8_t status2 = writeRegister(RES_XYZ_REG,
-                                  ((old_val & ~RES_XYZ_MASK) |
-                                  (res_xyz << RES_XYZ_SHIFT)) & RES_XYZ_MASK);
+                                  (old_val & ~RES_XYZ_MASK) |
+                                  ((res_xyz << RES_XYZ_SHIFT) & RES_XYZ_MASK));
   return checkStatus(status1) | checkStatus(status2);
 }
 


### PR DESCRIPTION
The mask must be applied only on changed bits, not on the whole register. This induced an erratic behaviour when changing resolution.